### PR TITLE
feat: add data models for user, level and progress tracking #64

### DIFF
--- a/lib/data/models/level_model.dart
+++ b/lib/data/models/level_model.dart
@@ -1,0 +1,125 @@
+/// LevelModel: clase de datos pura para representar un nivel de aprendizaje.
+/// - Sin dependencias de Firestore/Flutter (solo Dart).
+/// - Serializa fechas en ISO 8601 (string) para mantener independencia de infraestructura.
+class LevelModel {
+  final String id;
+  final String title;
+  final String description;
+  final int order;
+  final String difficulty;
+  final String? pictogramUrl;
+  final String? videoUrl;
+  final Map<String, dynamic>? minigameData;
+  final bool isActive;
+  final DateTime? createdAt;
+  final DateTime? updatedAt;
+
+  const LevelModel({
+    required this.id,
+    required this.title,
+    required this.description,
+    required this.order,
+    this.difficulty = 'easy',
+    this.pictogramUrl,
+    this.videoUrl,
+    this.minigameData,
+    this.isActive = true,
+    this.createdAt,
+    this.updatedAt,
+  });
+
+  LevelModel copyWith({
+    String? id,
+    String? title,
+    String? description,
+    int? order,
+    String? difficulty,
+    String? pictogramUrl,
+    String? videoUrl,
+    Map<String, dynamic>? minigameData,
+    bool? isActive,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return LevelModel(
+      id: id ?? this.id,
+      title: title ?? this.title,
+      description: description ?? this.description,
+      order: order ?? this.order,
+      difficulty: difficulty ?? this.difficulty,
+      pictogramUrl: pictogramUrl ?? this.pictogramUrl,
+      videoUrl: videoUrl ?? this.videoUrl,
+      minigameData: minigameData ?? this.minigameData,
+      isActive: isActive ?? this.isActive,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+    );
+  }
+
+  factory LevelModel.fromJson(Map<String, dynamic> json) {
+    return LevelModel(
+      id: (json['id'] ?? '').toString(),
+      title: (json['title'] ?? '').toString(),
+      description: (json['description'] ?? '').toString(),
+      order: _toInt(json['order']),
+      difficulty: (json['difficulty'] ?? 'easy').toString(),
+      pictogramUrl: json['pictogramUrl'] as String?,
+      videoUrl: json['videoUrl'] as String?,
+      minigameData: json['minigameData'] as Map<String, dynamic>?,
+      isActive: _toBool(json['isActive']),
+      createdAt: _toDateTime(json['createdAt']),
+      updatedAt: _toDateTime(json['updatedAt']),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    final map = <String, dynamic>{
+      'id': id,
+      'title': title,
+      'description': description,
+      'order': order,
+      'difficulty': difficulty,
+      'pictogramUrl': pictogramUrl,
+      'videoUrl': videoUrl,
+      'minigameData': minigameData,
+      'isActive': isActive,
+      'createdAt': createdAt?.toIso8601String(),
+      'updatedAt': updatedAt?.toIso8601String(),
+    };
+    map.removeWhere((_, v) => v == null);
+    return map;
+  }
+
+  static int _toInt(dynamic v) {
+    if (v == null) return 0;
+    if (v is int) return v;
+    if (v is double) return v.toInt();
+    if (v is String) return int.tryParse(v) ?? 0;
+    return 0;
+  }
+
+  static bool _toBool(dynamic v) {
+    if (v == null) return true;
+    if (v is bool) return v;
+    if (v is String) return v.toLowerCase() == 'true';
+    if (v is int) return v != 0;
+    return true;
+  }
+
+  static DateTime? _toDateTime(dynamic v) {
+    if (v == null) return null;
+    if (v is DateTime) return v;
+    if (v is int) return DateTime.fromMillisecondsSinceEpoch(v);
+    if (v is String) return DateTime.tryParse(v);
+    // Compatibilidad básica con objetos serializados tipo Timestamp sin importar paquete:
+    if (v is Map) {
+      final seconds = v['seconds'] ?? v['_seconds'];
+      final nanos = v['nanoseconds'] ?? v['_nanoseconds'];
+      if (seconds is int) {
+        final ms = seconds * 1000 + (nanos is int ? nanos ~/ 1000000 : 0);
+        return DateTime.fromMillisecondsSinceEpoch(ms);
+      }
+    }
+    return null;
+  }
+}

--- a/lib/data/models/progress_log_model.dart
+++ b/lib/data/models/progress_log_model.dart
@@ -1,0 +1,137 @@
+/// ProgressLogModel: clase de datos pura para representar el progreso del usuario.
+/// - Sin dependencias de Firestore/Flutter (solo Dart).
+/// - Serializa fechas en ISO 8601 (string) para mantener independencia de infraestructura.
+class ProgressLogModel {
+  final String id;
+  final String userId;
+  final String levelId;
+  final String status;
+  final int score;
+  final int attempts;
+  final int timeSpentSeconds;
+  final Map<String, dynamic>? sessionData;
+  final List<String>? achievements;
+  final DateTime? startedAt;
+  final DateTime? completedAt;
+  final DateTime? createdAt;
+  final DateTime? updatedAt;
+
+  const ProgressLogModel({
+    required this.id,
+    required this.userId,
+    required this.levelId,
+    this.status = 'in_progress',
+    this.score = 0,
+    this.attempts = 0,
+    this.timeSpentSeconds = 0,
+    this.sessionData,
+    this.achievements,
+    this.startedAt,
+    this.completedAt,
+    this.createdAt,
+    this.updatedAt,
+  });
+
+  ProgressLogModel copyWith({
+    String? id,
+    String? userId,
+    String? levelId,
+    String? status,
+    int? score,
+    int? attempts,
+    int? timeSpentSeconds,
+    Map<String, dynamic>? sessionData,
+    List<String>? achievements,
+    DateTime? startedAt,
+    DateTime? completedAt,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return ProgressLogModel(
+      id: id ?? this.id,
+      userId: userId ?? this.userId,
+      levelId: levelId ?? this.levelId,
+      status: status ?? this.status,
+      score: score ?? this.score,
+      attempts: attempts ?? this.attempts,
+      timeSpentSeconds: timeSpentSeconds ?? this.timeSpentSeconds,
+      sessionData: sessionData ?? this.sessionData,
+      achievements: achievements ?? this.achievements,
+      startedAt: startedAt ?? this.startedAt,
+      completedAt: completedAt ?? this.completedAt,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+    );
+  }
+
+  factory ProgressLogModel.fromJson(Map<String, dynamic> json) {
+    return ProgressLogModel(
+      id: (json['id'] ?? '').toString(),
+      userId: (json['userId'] ?? '').toString(),
+      levelId: (json['levelId'] ?? '').toString(),
+      status: (json['status'] ?? 'in_progress').toString(),
+      score: _toInt(json['score']),
+      attempts: _toInt(json['attempts']),
+      timeSpentSeconds: _toInt(json['timeSpentSeconds']),
+      sessionData: json['sessionData'] as Map<String, dynamic>?,
+      achievements: _toStringList(json['achievements']),
+      startedAt: _toDateTime(json['startedAt']),
+      completedAt: _toDateTime(json['completedAt']),
+      createdAt: _toDateTime(json['createdAt']),
+      updatedAt: _toDateTime(json['updatedAt']),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    final map = <String, dynamic>{
+      'id': id,
+      'userId': userId,
+      'levelId': levelId,
+      'status': status,
+      'score': score,
+      'attempts': attempts,
+      'timeSpentSeconds': timeSpentSeconds,
+      'sessionData': sessionData,
+      'achievements': achievements,
+      'startedAt': startedAt?.toIso8601String(),
+      'completedAt': completedAt?.toIso8601String(),
+      'createdAt': createdAt?.toIso8601String(),
+      'updatedAt': updatedAt?.toIso8601String(),
+    };
+    map.removeWhere((_, v) => v == null);
+    return map;
+  }
+
+  static int _toInt(dynamic v) {
+    if (v == null) return 0;
+    if (v is int) return v;
+    if (v is double) return v.toInt();
+    if (v is String) return int.tryParse(v) ?? 0;
+    return 0;
+  }
+
+  static List<String>? _toStringList(dynamic v) {
+    if (v == null) return null;
+    if (v is List) {
+      return v.map((e) => e.toString()).toList();
+    }
+    return null;
+  }
+
+  static DateTime? _toDateTime(dynamic v) {
+    if (v == null) return null;
+    if (v is DateTime) return v;
+    if (v is int) return DateTime.fromMillisecondsSinceEpoch(v);
+    if (v is String) return DateTime.tryParse(v);
+    // Compatibilidad básica con objetos serializados tipo Timestamp sin importar paquete:
+    if (v is Map) {
+      final seconds = v['seconds'] ?? v['_seconds'];
+      final nanos = v['nanoseconds'] ?? v['_nanoseconds'];
+      if (seconds is int) {
+        final ms = seconds * 1000 + (nanos is int ? nanos ~/ 1000000 : 0);
+        return DateTime.fromMillisecondsSinceEpoch(ms);
+      }
+    }
+    return null;
+  }
+}

--- a/lib/data/models/user_model.dart
+++ b/lib/data/models/user_model.dart
@@ -6,6 +6,8 @@ class UserModel {
   final String email;
   final String? displayName;
   final int monedas;
+  final String role;
+  final Map<String, dynamic>? avatarConfig;
   final DateTime? createdAt;
   final DateTime? updatedAt;
 
@@ -14,6 +16,8 @@ class UserModel {
     required this.email,
     this.displayName,
     this.monedas = 0,
+    this.role = 'patient',
+    this.avatarConfig,
     this.createdAt,
     this.updatedAt,
   });
@@ -23,6 +27,8 @@ class UserModel {
     String? email,
     String? displayName,
     int? monedas,
+    String? role,
+    Map<String, dynamic>? avatarConfig,
     DateTime? createdAt,
     DateTime? updatedAt,
   }) {
@@ -31,6 +37,8 @@ class UserModel {
       email: email ?? this.email,
       displayName: displayName ?? this.displayName,
       monedas: monedas ?? this.monedas,
+      role: role ?? this.role,
+      avatarConfig: avatarConfig ?? this.avatarConfig,
       createdAt: createdAt ?? this.createdAt,
       updatedAt: updatedAt ?? this.updatedAt,
     );
@@ -42,6 +50,8 @@ class UserModel {
       email: (json['email'] ?? '').toString(),
       displayName: json['displayName'] as String?,
       monedas: _toInt(json['monedas']),
+      role: (json['role'] ?? 'patient').toString(),
+      avatarConfig: json['avatarConfig'] as Map<String, dynamic>?,
       createdAt: _toDateTime(json['createdAt']),
       updatedAt: _toDateTime(json['updatedAt']),
     );
@@ -53,6 +63,8 @@ class UserModel {
       'email': email,
       'displayName': displayName,
       'monedas': monedas,
+      'role': role,
+      'avatarConfig': avatarConfig,
       'createdAt': createdAt?.toIso8601String(),
       'updatedAt': updatedAt?.toIso8601String(),
     };


### PR DESCRIPTION
UserModel (modificado):

> Agregados campos role y avatarConfig para personalización de usuario


LevelModel (nuevo):

> Modelo para niveles educativos con pictogramUrl, videoUrl y minigameData
> Incluye campos básicos: título, descripción, orden y dificultad

ProgressLogModel (nuevo):

> Seguimiento del progreso: puntaje, intentos, tiempo y logros
> Relación usuario-nivel con timestamps de sesión