### PR TITLE
feat: Implementar minigame de pictograma y mejoras en carrusel de con…

### DIFF
--- a/lib/features/learning_module/model/levels_models.dart
+++ b/lib/features/learning_module/model/levels_models.dart
@@ -37,7 +37,7 @@ class ModuleLevelInfo {
   final String? pictogramaUrl;
   final String? videoUrl;
   final String? audioUrl;
-  final String actividadType;
+  final String? actividadType; // Nullable para detectar cuando no hay actividad interactiva
   final Map<String, dynamic>? actividadData;
   final int estrellas;
   final StateOfStep estado;
@@ -50,7 +50,7 @@ class ModuleLevelInfo {
     this.pictogramaUrl,
     this.videoUrl,
     this.audioUrl,
-    required this.actividadType,
+    this.actividadType, // Ahora es nullable
     this.actividadData,
     this.estrellas = 0,
     this.estado = StateOfStep.blocked,
@@ -108,13 +108,31 @@ class ModuleLevelInfo {
       pictogramaUrl: data['pictogramaUrl']?.toString(),
       videoUrl: data['videoUrl']?.toString(),
       audioUrl: data['audioUrl']?.toString(),
-      actividadType: data['actividadType']?.toString() ?? 'simple_selection',
+      // Tratar null y cadenas vacías como null
+      actividadType: _parseActividadType(data['actividadType']),
       actividadData: actividadDataValue,
       estrellas: estrellasValue,
       estado: _parseEstado(data['estado']?.toString()),
     );
 
     return nivel;
+  }
+
+  /*
+  Helper para parsear actividadType desde Firestore.
+  Trata null, cadenas vacías y la cadena "null" como null.
+  */
+  static String? _parseActividadType(dynamic actividadType) {
+    if (actividadType == null) {
+      return null;
+    }
+    
+    final String str = actividadType.toString().trim();
+    if (str.isEmpty || str.toLowerCase() == 'null') {
+      return null;
+    }
+    
+    return str;
   }
 
   /*

--- a/lib/features/learning_module/view/fullscreen_view.dart
+++ b/lib/features/learning_module/view/fullscreen_view.dart
@@ -7,6 +7,8 @@ class FullScreenContentView extends StatefulWidget {
   final int initialIndex;
   final String levelName;
   final String? bgLevelImg;
+  final VoidCallback? onVideoCompleted;
+  final VoidCallback? onPictogramViewed;
 
   const FullScreenContentView({
     super.key,
@@ -14,6 +16,8 @@ class FullScreenContentView extends StatefulWidget {
     required this.initialIndex,
     required this.levelName,
     this.bgLevelImg,
+    this.onVideoCompleted,
+    this.onPictogramViewed,
   });
 
   @override
@@ -184,6 +188,7 @@ class _FullScreenContentViewState extends State<FullScreenContentView> {
           pictogramTitle: data.title,
           pictogramDesc: data.description ?? '',
           isPreview: false, // Modo fullscreen
+          onPictogramViewed: widget.onPictogramViewed,
         );
       case ContentType.video:
         return VideoPreviewCard(
@@ -191,6 +196,7 @@ class _FullScreenContentViewState extends State<FullScreenContentView> {
           videoTitle: data.title,
           videoDesc: data.description,
           isPreview: false, // Modo fullscreen
+          onVideoCompleted: widget.onVideoCompleted,
         );
       case ContentType.audio:
         return AudioPreviewCard(

--- a/lib/features/learning_module/view/level_play_screen.dart
+++ b/lib/features/learning_module/view/level_play_screen.dart
@@ -53,22 +53,36 @@ class _LevelPlayScreenState extends State<LevelPlayScreen> {
 
   @override
   Widget build(BuildContext context) {
+    // Si no hay actividadType, no deberíamos estar aquí (debería mostrar "COMPLETAR" en lugar de "JUGAR")
+    // Pero por seguridad, si llegamos aquí sin actividadType, volvemos atrás
+    if (widget.actividadType == null || widget.actividadType!.trim().isEmpty) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) {
+          Navigator.of(context).pop();
+        }
+      });
+      return Scaffold(
+        body: Center(
+          child: CircularProgressIndicator(),
+        ),
+      );
+    }
+    
     // Convertir actividadType directamente desde Firestore a MinigameType
     MinigameType minigameType;
-    if (widget.actividadType != null) {
-      switch (widget.actividadType!.toLowerCase().trim()) {
-        case 'simple_selection':
-          minigameType = MinigameType.simpleSelection;
-          break;
-        case 'video':
-          minigameType = MinigameType.video;
-          break;
-        // TODO: Agregar más casos cuando se implementen otros tipos
-        default:
-          minigameType = MinigameType.simpleSelection; // Fallback por defecto
-      }
-    } else {
-      minigameType = MinigameType.simpleSelection; // Fallback por defecto
+    switch (widget.actividadType!.toLowerCase().trim()) {
+      case 'simple_selection':
+        minigameType = MinigameType.simpleSelection;
+        break;
+      case 'video':
+        minigameType = MinigameType.video;
+        break;
+      case 'pictogram':
+        minigameType = MinigameType.pictogram;
+        break;
+      // TODO: Agregar más casos cuando se implementen otros tipos
+      default:
+        minigameType = MinigameType.simpleSelection; // Fallback por defecto
     }
     
     return Scaffold(

--- a/lib/features/learning_module/viewmodel/learning_viewmodel.dart
+++ b/lib/features/learning_module/viewmodel/learning_viewmodel.dart
@@ -227,6 +227,23 @@ class LearningViewModel extends ChangeNotifier {
   }
 
   /*
+  Helper para parsear actividadType desde Firestore.
+  Trata null, cadenas vacías y la cadena "null" como null.
+  */
+  String? _parseActividadType(dynamic actividadType) {
+    if (actividadType == null) {
+      return null;
+    }
+    
+    final String str = actividadType.toString().trim();
+    if (str.isEmpty || str.toLowerCase() == 'null') {
+      return null;
+    }
+    
+    return str;
+  }
+
+  /*
   Crea un ModuleLevelInfo desde datos de Firestore
   */
   ModuleLevelInfo _createModuleLevelInfoWithProgress(
@@ -279,7 +296,8 @@ class LearningViewModel extends ChangeNotifier {
       pictogramaUrl: data['pictogramaUrl']?.toString(),
       videoUrl: data['videoUrl']?.toString(),
       audioUrl: data['audioUrl']?.toString(),
-      actividadType: data['actividadType']?.toString() ?? 'simple_selection',
+      // Tratar null y cadenas vacías como null
+      actividadType: _parseActividadType(data['actividadType']),
       actividadData: actividadDataValue,
       estrellas: estrellasValue,
       estado: StateOfStep.blocked, // Se determinará después

--- a/lib/features/learning_module/viewmodel/video_viewmodel.dart
+++ b/lib/features/learning_module/viewmodel/video_viewmodel.dart
@@ -27,9 +27,12 @@ class VideoViewModel extends ChangeNotifier {
       _isExternalController = true;
       if (_videoController.value.isInitialized) {
         _initializeVideoFuture = Future.value();
+        // Asegurarse de que el loop esté desactivado (no reproducir automáticamente)
+        _videoController.setLooping(false);
       } else {
         _initializeVideoFuture = _videoController.initialize().then((_) {
-          _videoController.setLooping(true);
+          // Desactivar loop por defecto - el video solo se reproduce cuando el usuario lo inicia
+          _videoController.setLooping(false);
         });
       }
     }
@@ -50,6 +53,8 @@ class VideoViewModel extends ChangeNotifier {
 
   void replay() {
     _videoController.seekTo(Duration.zero);
+    // Asegurarse de que el loop esté desactivado para que solo se reproduzca una vez
+    _videoController.setLooping(false);
     _videoController.play();
     _showTemporaryIcon();
   }

--- a/lib/features/minigames/minigame_core.dart
+++ b/lib/features/minigames/minigame_core.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 enum MinigameType {
   simpleSelection, // primer minijuego especificado en el issue #65
   video, // minijuego de video tutorial
+  pictogram, // minijuego de pictograma
   // TODO: Agregar más tipos de minijuegos a medida que se implementen
 }
 

--- a/lib/features/minigames/view/types/pictogram_minigame.dart
+++ b/lib/features/minigames/view/types/pictogram_minigame.dart
@@ -1,0 +1,258 @@
+import 'package:flutter/material.dart';
+import '../../minigame_core.dart';
+
+/// Minijuego de Pictograma
+/// Muestra un pictograma a pantalla completa como actividad
+/// El usuario debe presionar "Completar" para finalizar la actividad
+class PictogramMinigame extends MinigameBase {
+  const PictogramMinigame({
+    super.key,
+    required super.onComplete,
+    required super.minigameData,
+  });
+
+  @override
+  State<PictogramMinigame> createState() => _PictogramMinigameState();
+}
+
+class _PictogramMinigameState extends State<PictogramMinigame> {
+  bool _isCompleted = false;
+
+  @override
+  Widget build(BuildContext context) {
+    // Obtener pictogramaUrl desde actividadData o desde el nivel
+    // Puede venir en actividadData['pictogramaUrl'] o directamente en minigameData['pictogramaUrl']
+    final pictogramaUrl = widget.minigameData['pictogramaUrl'] as String?;
+    final title = widget.minigameData['title'] as String? ?? 
+                  widget.minigameData['titulo'] as String? ?? 
+                  'Pictograma';
+    final description = widget.minigameData['description'] as String? ?? 
+                       widget.minigameData['descripcion'] as String?;
+
+    if (pictogramaUrl == null || pictogramaUrl.isEmpty) {
+      return Scaffold(
+        backgroundColor: const Color(0xFF091F2C),
+        body: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const Icon(
+                Icons.image_not_supported,
+                size: 80,
+                color: Colors.white54,
+              ),
+              const SizedBox(height: 16),
+              const Text(
+                'No se encontró el pictograma',
+                style: TextStyle(
+                  color: Colors.white,
+                  fontSize: 18,
+                ),
+              ),
+              const SizedBox(height: 24),
+              ElevatedButton(
+                onPressed: () => widget.onComplete(false, 1),
+                child: const Text('Volver'),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    return Scaffold(
+      backgroundColor: const Color(0xFF091F2C),
+      body: SafeArea(
+        child: Column(
+          children: [
+            // Header con título
+            Container(
+              padding: const EdgeInsets.all(16),
+              decoration: const BoxDecoration(
+                gradient: LinearGradient(
+                  begin: Alignment.topLeft,
+                  end: Alignment.bottomRight,
+                  colors: [Color(0xFF2C5F7A), Color(0xFF1A3D52)],
+                ),
+                border: Border(
+                  bottom: BorderSide(
+                    color: Color(0x66FFFFFF),
+                    width: 1.5,
+                  ),
+                ),
+              ),
+              child: Row(
+                children: [
+                  IconButton(
+                    icon: const Icon(Icons.arrow_back, color: Colors.white),
+                    onPressed: () => Navigator.of(context).pop(),
+                  ),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          title,
+                          style: const TextStyle(
+                            fontSize: 22,
+                            fontWeight: FontWeight.bold,
+                            color: Colors.white,
+                          ),
+                        ),
+                        if (description != null && description.isNotEmpty) ...[
+                          const SizedBox(height: 4),
+                          Text(
+                            description,
+                            style: const TextStyle(
+                              fontSize: 14,
+                              color: Colors.white70,
+                            ),
+                            maxLines: 2,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ],
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+
+            // Pictograma a pantalla completa
+            Expanded(
+              child: Center(
+                child: Container(
+                  margin: const EdgeInsets.all(20),
+                  decoration: BoxDecoration(
+                    color: Colors.white,
+                    borderRadius: BorderRadius.circular(20),
+                    border: Border.all(
+                      color: const Color(0x997BA5C9),
+                      width: 2,
+                    ),
+                    boxShadow: const [
+                      BoxShadow(
+                        color: Color(0x80000000),
+                        blurRadius: 30,
+                        spreadRadius: 5,
+                        offset: Offset(0, 10),
+                      ),
+                    ],
+                  ),
+                  child: ClipRRect(
+                    borderRadius: BorderRadius.circular(18),
+                    child: _buildImageFromUrl(
+                      pictogramaUrl,
+                      fit: BoxFit.contain,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+
+            // Botón Completar
+            Padding(
+              padding: const EdgeInsets.all(20),
+              child: ElevatedButton.icon(
+                onPressed: _isCompleted
+                    ? null
+                    : () {
+                        setState(() {
+                          _isCompleted = true;
+                        });
+                        widget.onComplete(true, 1);
+                      },
+                icon: const Icon(Icons.check_circle_rounded, size: 32),
+                label: const Text(
+                  'COMPLETAR',
+                  style: TextStyle(
+                    fontSize: 20,
+                    fontWeight: FontWeight.bold,
+                    letterSpacing: 1.5,
+                  ),
+                ),
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: _isCompleted
+                      ? Colors.grey
+                      : const Color(0xFF05E995),
+                  foregroundColor: Colors.white,
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 40,
+                    vertical: 15,
+                  ),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(30),
+                  ),
+                  elevation: 10,
+                  shadowColor: const Color.fromARGB(204, 5, 233, 149),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// Helper function para construir imágenes desde URLs
+  /// Detecta automáticamente si es un asset local o URL externa
+  /// Permite usar URLs tal cual están en la base de datos sin agregar prefijos automáticos
+  Widget _buildImageFromUrl(
+    String url, {
+    BoxFit fit = BoxFit.contain,
+  }) {
+    // Si la URL es una URL externa (http/https), usar Image.network
+    if (url.startsWith('http://') || url.startsWith('https://')) {
+      return Image.network(
+        url,
+        fit: fit,
+        errorBuilder: (context, error, stackTrace) {
+          return const Center(
+            child: Icon(
+              Icons.image_not_supported,
+              size: 80,
+              color: Color(0xFFCCCCCC),
+            ),
+          );
+        },
+        loadingBuilder: (context, child, loadingProgress) {
+          if (loadingProgress == null) return child;
+          return const Center(
+            child: CircularProgressIndicator(
+              color: Color(0xFF5B8DB3),
+            ),
+          );
+        },
+      );
+    }
+
+    // Si es un asset local, usar Image.asset directamente con la URL tal cual está
+    // No agregamos "assets/" porque la URL ya viene completa desde la BD
+    return Image.asset(
+      url,
+      fit: fit,
+      errorBuilder: (context, error, stackTrace) {
+        return const Center(
+          child: Icon(
+            Icons.image_not_supported,
+            size: 80,
+            color: Color(0xFFCCCCCC),
+          ),
+        );
+      },
+    );
+  }
+}
+
+/// Registrar este minijuego con el factory
+/// Debe ser llamado durante la inicialización de la app (main.dart)
+void registerPictogramMinigame() {
+  MinigameFactory.register(
+    MinigameType.pictogram,
+    ({required onComplete, required minigameData}) => PictogramMinigame(
+      onComplete: onComplete,
+      minigameData: minigameData,
+    ),
+  );
+}
+

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -24,6 +24,7 @@ import 'shared/widgets/loading_wrapper.dart';
 // Minigames
 import 'features/minigames/view/types/simple_selection_minigame.dart';
 import 'features/minigames/view/types/video_minigame.dart';
+import 'features/minigames/view/types/pictogram_minigame.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -34,6 +35,7 @@ void main() async {
   // Registrar minijuegos
   registerSimpleSelectionMinigame();
   registerVideoMinigame();
+  registerPictogramMinigame();
 
   runApp(const MyApp());
 }


### PR DESCRIPTION
**Implementación de minigame de pictograma y mejoras en carrusel de contenido**

**Funcionalidades implementadas:**
- Minigame de pictograma como actividad en niveles
- Botón "COMPLETAR" para niveles de solo observación (sin actividad interactiva)
- Validación de visualización de contenido: video 90% y pictograma 10 segundos
- Mejoras en la lógica de botones JUGAR/COMPLETAR según el tipo de nivel
- Ajustes de posicionamiento del botón de regresar en el carrusel

**Cambios técnicos:**
- Nuevo archivo `pictogram_minigame.dart` para el minigame de pictograma
- Actualización de `MinigameType` para incluir `pictogram`
- Mejoras en el parsing de `actividadType` para manejar valores null
- Desactivación de autoplay y loop en videos
- Tracking de visualización de contenido en preview cards

**Archivos modificados:**
- `pictogram_minigame.dart` (nuevo)
- `minigame_core.dart`
- `level_play_screen.dart`
- `level_content_screen.dart`
- `preview_cards.dart`
- `fullscreen_view.dart`
- `video_viewmodel.dart`
- `levels_models.dart`
- `learning_viewmodel.dart`
- `main.dart`