### PR TITLE
Task/re-add-videoplayer

### DIFF
--- a/lib/features/learning_module/view/fullscreen_view.dart
+++ b/lib/features/learning_module/view/fullscreen_view.dart
@@ -75,7 +75,11 @@ class _FullScreenContentViewState extends State<FullScreenContentView> {
               Positioned.fill(
                 child: Opacity(
                   opacity: 0.2,
-                  child: Image.asset(widget.bgLevelImg!, fit: BoxFit.cover),
+                  child: widget.bgLevelImg!.startsWith('http')
+                      ? Image.network(widget.bgLevelImg!, fit: BoxFit.cover,
+                          errorBuilder: (_, __, ___) => const SizedBox.shrink())
+                      : Image.asset(widget.bgLevelImg!, fit: BoxFit.cover,
+                          errorBuilder: (_, __, ___) => const SizedBox.shrink()),
                 ),
               ),
 

--- a/lib/features/learning_module/view/level_content_screen.dart
+++ b/lib/features/learning_module/view/level_content_screen.dart
@@ -19,6 +19,8 @@ class LevelContentPreviewScreen extends StatefulWidget {
   final String? levelId;
   final String? moduleId;
   final String? levelTitle;
+  /// URL del video para niveles de tipo 'video' (desde Firebase Storage)
+  final String? videoUrl;
 
   const LevelContentPreviewScreen({
     super.key,
@@ -30,6 +32,7 @@ class LevelContentPreviewScreen extends StatefulWidget {
     this.levelId,
     this.moduleId,
     this.levelTitle,
+    this.videoUrl,
   });
 
   @override
@@ -130,8 +133,13 @@ class _LevelContentPreviewScreenState extends State<LevelContentPreviewScreen>
 
                   const SizedBox(height: 20),
                   
-                  // Botón "JUGAR" si hay actividadType (minijuego interactivo)
-                  if (_hasValidActividadType && widget.minigameData != null)
+                  // Botón "JUGAR" si hay actividadType (minijuego interactivo o video)
+                  // Para video: siempre mostrar si actividadType es 'video' y hay videoUrl
+                  // Para otros tipos: mostrar solo si hay minigameData
+                  if (_hasValidActividadType &&
+                      (widget.actividadType!.toLowerCase().trim() == 'video'
+                          ? (widget.videoUrl != null && widget.videoUrl!.isNotEmpty)
+                          : widget.minigameData != null))
                     Padding(
                       padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 10),
                       child: ElevatedButton.icon(
@@ -141,10 +149,11 @@ class _LevelContentPreviewScreenState extends State<LevelContentPreviewScreen>
                             MaterialPageRoute(
                               builder: (context) => LevelPlayScreen(
                                 levelTitle: widget.levelTitle ?? widget.levelName,
-                                minigameData: widget.minigameData!,
+                                minigameData: widget.minigameData,
                                 actividadType: widget.actividadType!,
                                 levelId: widget.levelId ?? '',
                                 moduleId: widget.moduleId ?? '',
+                                videoUrl: widget.videoUrl,
                               ),
                             ),
                           );
@@ -154,10 +163,18 @@ class _LevelContentPreviewScreenState extends State<LevelContentPreviewScreen>
                             await learningViewModel.getModuleLevels(widget.moduleId!, forceReload: true);
                           }
                         },
-                        icon: const Icon(Icons.play_arrow_rounded, color: Colors.white, size: 32),
-                        label: const Text(
-                          'JUGAR',
-                          style: TextStyle(
+                        icon: Icon(
+                          widget.actividadType!.toLowerCase().trim() == 'video'
+                              ? Icons.play_circle_rounded
+                              : Icons.play_arrow_rounded,
+                          color: Colors.white,
+                          size: 32,
+                        ),
+                        label: Text(
+                          widget.actividadType!.toLowerCase().trim() == 'video'
+                              ? 'VER VIDEO'
+                              : 'JUGAR',
+                          style: const TextStyle(
                             fontSize: 20,
                             fontWeight: FontWeight.bold,
                             color: Colors.white,
@@ -165,7 +182,9 @@ class _LevelContentPreviewScreenState extends State<LevelContentPreviewScreen>
                           ),
                         ),
                         style: ElevatedButton.styleFrom(
-                          backgroundColor: const Color(0xFF00E5FF),
+                          backgroundColor: widget.actividadType!.toLowerCase().trim() == 'video'
+                              ? const Color(0xFF5A97B8)
+                              : const Color(0xFF00E5FF),
                           padding: const EdgeInsets.symmetric(horizontal: 40, vertical: 15),
                           shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(30)),
                           elevation: 10,

--- a/lib/features/learning_module/view/level_play_screen.dart
+++ b/lib/features/learning_module/view/level_play_screen.dart
@@ -1,10 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:provider/provider.dart';
+import 'package:video_player/video_player.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 import '../../minigames/minigame_core.dart';
 import '../../minigames/view/minigames_widget.dart';
 import '../../../data/services/firestore_services.dart';
 import '../viewmodel/learning_viewmodel.dart';
+import '../viewmodel/video_viewmodel.dart';
 import '../../avatar/viewmodel/avatar_viewmodel.dart';
 
 /// Pantalla de juego de nivel
@@ -15,6 +18,8 @@ class LevelPlayScreen extends StatefulWidget {
   final String? actividadType;
   final String? levelId;
   final String? moduleId;
+  /// URL del video (desde Firebase Storage o Firestore) para niveles de tipo 'video'
+  final String? videoUrl;
 
   const LevelPlayScreen({
     super.key,
@@ -23,6 +28,7 @@ class LevelPlayScreen extends StatefulWidget {
     this.actividadType,
     this.levelId,
     this.moduleId,
+    this.videoUrl,
   });
 
   @override
@@ -67,15 +73,64 @@ class _LevelPlayScreenState extends State<LevelPlayScreen> {
         ),
       );
     }
-    
+
+    final type = widget.actividadType!.toLowerCase().trim();
+
+    // Manejo especial para niveles de tipo 'video': mostrar reproductor de video
+    if (type == 'video') {
+      final url = widget.videoUrl ??
+          (widget.minigameData?['videoUrl'] as String?) ??
+          (widget.minigameData?['url'] as String?);
+
+      if (url == null || url.isEmpty) {
+        return Scaffold(
+          backgroundColor: Colors.black,
+          body: SafeArea(
+            child: Column(
+              children: [
+                Align(
+                  alignment: Alignment.topLeft,
+                  child: IconButton(
+                    icon: const Icon(Icons.arrow_back, color: Colors.white),
+                    onPressed: () => Navigator.of(context).pop(),
+                  ),
+                ),
+                const Expanded(
+                  child: Center(
+                    child: Text(
+                      'No hay video disponible para este nivel.',
+                      style: TextStyle(color: Colors.white70, fontSize: 16),
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      }
+
+      return _LevelVideoPlayerScreen(
+        videoUrl: url,
+        levelTitle: widget.levelTitle,
+        levelId: widget.levelId,
+        moduleId: widget.moduleId,
+        onCompleted: (success) async {
+          if (success) {
+            await _saveProgress(context, true, 1);
+          }
+          if (context.mounted) {
+            Navigator.of(context).pop();
+          }
+        },
+      );
+    }
+
     // Convertir actividadType directamente desde Firestore a MinigameType
     MinigameType minigameType;
-    switch (widget.actividadType!.toLowerCase().trim()) {
+    switch (type) {
       case 'simple_selection':
         minigameType = MinigameType.simpleSelection;
-        break;
-      case 'video':
-        minigameType = MinigameType.video;
         break;
       case 'pictogram':
         minigameType = MinigameType.pictogram;
@@ -466,6 +521,290 @@ class _LevelPlayScreenState extends State<LevelPlayScreen> {
         {'imagePath': 'assets/images/MEH.png', 'label': 'Opción 3'},
       ],
     };
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Widget de reproductor de video para niveles con actividadType == 'video'
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Pantalla dedicada al reproductor de video para niveles de tipo 'video'.
+/// Muestra el video en pantalla completa con controles y marca el nivel como
+/// completado cuando el usuario ha visto al menos el 90% del video.
+class _LevelVideoPlayerScreen extends StatefulWidget {
+  final String videoUrl;
+  final String levelTitle;
+  final String? levelId;
+  final String? moduleId;
+  final void Function(bool success) onCompleted;
+
+  const _LevelVideoPlayerScreen({
+    required this.videoUrl,
+    required this.levelTitle,
+    required this.onCompleted,
+    this.levelId,
+    this.moduleId,
+  });
+
+  @override
+  State<_LevelVideoPlayerScreen> createState() =>
+      _LevelVideoPlayerScreenState();
+}
+
+class _LevelVideoPlayerScreenState extends State<_LevelVideoPlayerScreen> {
+  late VideoViewModel _viewModel;
+  bool _hasNotifiedCompletion = false;
+  bool _isCompleted = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _viewModel = VideoViewModel();
+    _viewModel.initialize(widget.videoUrl, null);
+    _viewModel.addListener(_onVideoUpdate);
+  }
+
+  void _onVideoUpdate() {
+    if (!mounted) return;
+    setState(() {});
+
+    if (_hasNotifiedCompletion) return;
+
+    try {
+      final controller = _viewModel.videoController;
+      if (!controller.value.isInitialized) return;
+
+      final position = controller.value.position;
+      final duration = controller.value.duration;
+
+      if (duration.inMilliseconds <= 0) return;
+
+      final progress = position.inMilliseconds / duration.inMilliseconds;
+      final isAtEnd = position >= duration;
+
+      if (progress >= 0.9 || isAtEnd) {
+        _hasNotifiedCompletion = true;
+        setState(() => _isCompleted = true);
+        // Pause when done
+        if (controller.value.isPlaying) {
+          controller.pause();
+        }
+      }
+    } catch (_) {}
+  }
+
+  @override
+  void dispose() {
+    _viewModel.removeListener(_onVideoUpdate);
+    _viewModel.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.black,
+      body: SafeArea(
+        child: FutureBuilder<void>(
+          future: _viewModel.initializeVideoFuture,
+          builder: (context, snapshot) {
+            final ready = snapshot.connectionState == ConnectionState.done &&
+                snapshot.error == null;
+
+            return Column(
+              children: [
+                // ── Top bar ──────────────────────────────────────────────────
+                Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+                  decoration: const BoxDecoration(
+                    gradient: LinearGradient(
+                      begin: Alignment.topCenter,
+                      end: Alignment.bottomCenter,
+                      colors: [Color(0xCC000000), Colors.transparent],
+                    ),
+                  ),
+                  child: Row(
+                    children: [
+                      IconButton(
+                        icon: const Icon(Icons.arrow_back, color: Colors.white),
+                        onPressed: () => Navigator.of(context).pop(),
+                      ),
+                      Expanded(
+                        child: Text(
+                          widget.levelTitle,
+                          style: const TextStyle(
+                            color: Colors.white,
+                            fontSize: 18,
+                            fontWeight: FontWeight.bold,
+                          ),
+                          textAlign: TextAlign.center,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                      const SizedBox(width: 48),
+                    ],
+                  ),
+                ),
+
+                // ── Video area ────────────────────────────────────────────────
+                Expanded(
+                  child: ready
+                      ? GestureDetector(
+                          onTap: _viewModel.togglePlayPause,
+                          child: Stack(
+                            alignment: Alignment.center,
+                            children: [
+                              Center(
+                                child: AspectRatio(
+                                  aspectRatio:
+                                      _viewModel.videoController.value.aspectRatio,
+                                  child: VideoPlayer(_viewModel.videoController),
+                                ),
+                              ),
+                              // Giant play/pause icon
+                              AnimatedOpacity(
+                                opacity: _viewModel.showGiantIcon ? 1.0 : 0.0,
+                                duration: const Duration(milliseconds: 300),
+                                child: SvgPicture.asset(
+                                  _viewModel.videoController.value.isPlaying
+                                      ? 'assets/icons/pausebigbutton.svg'
+                                      : 'assets/icons/playbigbutton.svg',
+                                  width: 80,
+                                  height: 80,
+                                ),
+                              ),
+                            ],
+                          ),
+                        )
+                      : snapshot.connectionState != ConnectionState.done
+                          ? const Center(
+                              child: CircularProgressIndicator(color: Colors.white),
+                            )
+                          : Center(
+                              child: Padding(
+                                padding: const EdgeInsets.all(24),
+                                child: Column(
+                                  mainAxisSize: MainAxisSize.min,
+                                  children: [
+                                    const Icon(Icons.error_outline,
+                                        color: Colors.red, size: 64),
+                                    const SizedBox(height: 12),
+                                    Text(
+                                      'No se pudo cargar el video.\n${snapshot.error}',
+                                      style: const TextStyle(
+                                          color: Colors.white70, fontSize: 14),
+                                      textAlign: TextAlign.center,
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            ),
+                ),
+
+                // ── Bottom controls ───────────────────────────────────────────
+                if (ready)
+                  Container(
+                    padding: const EdgeInsets.fromLTRB(16, 10, 16, 16),
+                    color: const Color(0xCC000000),
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        // Progress bar
+                        VideoProgressIndicator(
+                          _viewModel.videoController,
+                          allowScrubbing: true,
+                          colors: const VideoProgressColors(
+                            playedColor: Color(0xFF00E5FF),
+                            bufferedColor: Colors.white38,
+                            backgroundColor: Colors.white24,
+                          ),
+                        ),
+                        const SizedBox(height: 4),
+                        // Controls row — use GestureDetector instead of IconButton
+                        // to avoid the 48px minimum touch target enforcing an overflow
+                        // on narrow screens.
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            // Replay
+                            GestureDetector(
+                              onTap: () {
+                                _viewModel.replay();
+                                setState(() {
+                                  _hasNotifiedCompletion = false;
+                                  _isCompleted = false;
+                                });
+                              },
+                              child: SvgPicture.asset(
+                                'assets/icons/replay.svg',
+                                width: 28,
+                                height: 28,
+                              ),
+                            ),
+                            const SizedBox(width: 20),
+                            // Play / Pause
+                            GestureDetector(
+                              onTap: _viewModel.togglePlayPause,
+                              child: SvgPicture.asset(
+                                _viewModel.videoController.value.isPlaying
+                                    ? 'assets/icons/pausebutton.svg'
+                                    : 'assets/icons/playbuttoncontroller.svg',
+                                width: 36,
+                                height: 36,
+                              ),
+                            ),
+                            const SizedBox(width: 20),
+                            // Time label — Expanded so it takes remaining space
+                            // and never pushes the row past the screen edge.
+                            Expanded(
+                              child: Text(
+                                '${_viewModel.formatDuration(_viewModel.videoController.value.position)} / '
+                                '${_viewModel.formatDuration(_viewModel.videoController.value.duration)}',
+                                style: const TextStyle(
+                                    color: Colors.white, fontSize: 13),
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                            ),
+                          ],
+                        ),
+                        // "COMPLETAR" button
+                        if (_isCompleted) ...[
+                          const SizedBox(height: 10),
+                          SizedBox(
+                            width: double.infinity,
+                            child: ElevatedButton.icon(
+                              onPressed: () => widget.onCompleted(true),
+                              icon: const Icon(Icons.check_circle_rounded,
+                                  color: Colors.white),
+                              label: const Text(
+                                'COMPLETAR',
+                                style: TextStyle(
+                                  fontSize: 18,
+                                  fontWeight: FontWeight.bold,
+                                  color: Colors.white,
+                                  letterSpacing: 1.2,
+                                ),
+                              ),
+                              style: ElevatedButton.styleFrom(
+                                backgroundColor: const Color(0xFF05E995),
+                                padding: const EdgeInsets.symmetric(vertical: 12),
+                                shape: RoundedRectangleBorder(
+                                    borderRadius: BorderRadius.circular(30)),
+                                elevation: 10,
+                                shadowColor: const Color(0x8005E995),
+                              ),
+                            ),
+                          ),
+                        ],
+                      ],
+                    ),
+                  ),
+              ],
+            );
+          },
+        ),
+      ),
+    );
   }
 }
 

--- a/lib/features/learning_module/view/level_play_screen.dart
+++ b/lib/features/learning_module/view/level_play_screen.dart
@@ -115,6 +115,7 @@ class _LevelPlayScreenState extends State<LevelPlayScreen> {
         levelTitle: widget.levelTitle,
         levelId: widget.levelId,
         moduleId: widget.moduleId,
+        previewImageUrl: widget.minigameData?['pictogramaUrl'] as String?,
         onCompleted: (success) async {
           if (success) {
             await _saveProgress(context, true, 1);
@@ -232,29 +233,8 @@ class _LevelPlayScreenState extends State<LevelPlayScreen> {
 
   /// Construye la imagen del pictograma para mostrar en el diálogo
   Widget _buildPictogramImage(Map<String, dynamic> minigameData) {
-    // Obtener la URL del pictograma - intentar obtener la última imagen si hay steps
-    String? imageUrl;
-    
-    // Si hay steps, obtener la última imagen (la que se completó)
-    if (minigameData['steps'] != null) {
-      final steps = minigameData['steps'];
-      if (steps is List && steps.isNotEmpty) {
-        // Obtener la última imagen del carrusel
-        final lastStep = steps[steps.length - 1];
-        if (lastStep is Map) {
-          imageUrl = lastStep['url'] ?? lastStep['src'];
-        } else if (lastStep is String) {
-          imageUrl = lastStep;
-        }
-      }
-    }
-    
-    // Si no hay steps o no se encontró, intentar obtener pictogramaUrl directo
-    if (imageUrl == null || imageUrl.isEmpty) {
-      imageUrl = minigameData['pictogramaUrl'] as String?;
-    }
-    
-    // Si no hay imagen, retornar un placeholder
+    final imageUrl = minigameData['pictogramaUrl'] as String?;
+
     if (imageUrl == null || imageUrl.isEmpty) {
       return const SizedBox.shrink();
     }
@@ -536,6 +516,7 @@ class _LevelVideoPlayerScreen extends StatefulWidget {
   final String levelTitle;
   final String? levelId;
   final String? moduleId;
+  final String? previewImageUrl;
   final void Function(bool success) onCompleted;
 
   const _LevelVideoPlayerScreen({
@@ -544,6 +525,7 @@ class _LevelVideoPlayerScreen extends StatefulWidget {
     required this.onCompleted,
     this.levelId,
     this.moduleId,
+    this.previewImageUrl,
   });
 
   @override
@@ -555,6 +537,7 @@ class _LevelVideoPlayerScreenState extends State<_LevelVideoPlayerScreen> {
   late VideoViewModel _viewModel;
   bool _hasNotifiedCompletion = false;
   bool _isCompleted = false;
+  bool _hasStartedPlaying = false;
 
   @override
   void initState() {
@@ -648,35 +631,8 @@ class _LevelVideoPlayerScreenState extends State<_LevelVideoPlayerScreen> {
 
                 // ── Video area ────────────────────────────────────────────────
                 Expanded(
-                  child: ready
-                      ? GestureDetector(
-                          onTap: _viewModel.togglePlayPause,
-                          child: Stack(
-                            alignment: Alignment.center,
-                            children: [
-                              Center(
-                                child: AspectRatio(
-                                  aspectRatio:
-                                      _viewModel.videoController.value.aspectRatio,
-                                  child: VideoPlayer(_viewModel.videoController),
-                                ),
-                              ),
-                              // Giant play/pause icon
-                              AnimatedOpacity(
-                                opacity: _viewModel.showGiantIcon ? 1.0 : 0.0,
-                                duration: const Duration(milliseconds: 300),
-                                child: SvgPicture.asset(
-                                  _viewModel.videoController.value.isPlaying
-                                      ? 'assets/icons/pausebigbutton.svg'
-                                      : 'assets/icons/playbigbutton.svg',
-                                  width: 80,
-                                  height: 80,
-                                ),
-                              ),
-                            ],
-                          ),
-                        )
-                      : snapshot.connectionState != ConnectionState.done
+                  child: !ready
+                      ? (snapshot.connectionState != ConnectionState.done
                           ? const Center(
                               child: CircularProgressIndicator(color: Colors.white),
                             )
@@ -698,7 +654,69 @@ class _LevelVideoPlayerScreenState extends State<_LevelVideoPlayerScreen> {
                                   ],
                                 ),
                               ),
-                            ),
+                            ))
+                      // ── Ready: show cover until first play, then video ──────
+                      : GestureDetector(
+                          onTap: () {
+                            setState(() => _hasStartedPlaying = true);
+                            _viewModel.togglePlayPause();
+                          },
+                          child: Stack(
+                            alignment: Alignment.center,
+                            fit: StackFit.expand,
+                            children: [
+                              Container(color: Colors.black),
+                              // Video (always rendered so it buffers in background)
+                              Center(
+                                child: AspectRatio(
+                                  aspectRatio:
+                                      _viewModel.videoController.value.aspectRatio,
+                                  child: VideoPlayer(_viewModel.videoController),
+                                ),
+                              ),
+                              // Cover image — shown until user first presses play
+                              if (!_hasStartedPlaying)
+                                Center(
+                                  child: AspectRatio(
+                                    aspectRatio:
+                                        _viewModel.videoController.value.aspectRatio,
+                                    child: widget.previewImageUrl != null &&
+                                            widget.previewImageUrl!.isNotEmpty
+                                        ? Image.network(
+                                            widget.previewImageUrl!,
+                                            fit: BoxFit.cover,
+                                            errorBuilder: (_, __, ___) =>
+                                                Container(color: Colors.black),
+                                          )
+                                        : Container(color: Colors.black),
+                                  ),
+                                ),
+                              // Play button on cover / play-pause icon during playback
+                              if (!_hasStartedPlaying)
+                                const Center(
+                                  child: Icon(
+                                    Icons.play_circle_fill_rounded,
+                                    color: Colors.white70,
+                                    size: 72,
+                                  ),
+                                )
+                              else
+                                AnimatedOpacity(
+                                  opacity: _viewModel.showGiantIcon ? 1.0 : 0.0,
+                                  duration: const Duration(milliseconds: 300),
+                                  child: Center(
+                                    child: SvgPicture.asset(
+                                      _viewModel.videoController.value.isPlaying
+                                          ? 'assets/icons/pausebigbutton.svg'
+                                          : 'assets/icons/playbigbutton.svg',
+                                      width: 80,
+                                      height: 80,
+                                    ),
+                                  ),
+                                ),
+                            ],
+                          ),
+                        ),
                 ),
 
                 // ── Bottom controls ───────────────────────────────────────────
@@ -731,6 +749,7 @@ class _LevelVideoPlayerScreenState extends State<_LevelVideoPlayerScreen> {
                               onTap: () {
                                 _viewModel.replay();
                                 setState(() {
+                                  _hasStartedPlaying = true;
                                   _hasNotifiedCompletion = false;
                                   _isCompleted = false;
                                 });

--- a/lib/features/learning_module/view/level_timeline_screen.dart
+++ b/lib/features/learning_module/view/level_timeline_screen.dart
@@ -424,6 +424,7 @@ class _LevelTimelineScreenState extends State<LevelTimelineContent>
               levelId: step.levelId,
               moduleId: step.moduleId,
               levelTitle: step.previewTitle,
+              videoUrl: levelInfo.videoUrl,
             ),
           ),
         );
@@ -630,6 +631,7 @@ class _LevelTimelineScreenState extends State<LevelTimelineContent>
                         levelId: step.levelId,
                         moduleId: step.moduleId,
                         levelTitle: step.previewTitle,
+                        videoUrl: levelInfo.videoUrl,
                       ),
                     ),
                   );
@@ -750,7 +752,19 @@ class _LevelTimelineScreenState extends State<LevelTimelineContent>
   List<ContentCardData> _buildContentFromLevel(ModuleLevelInfo level) {
     final List<ContentCardData> contents = [];
 
-    // 1. PRIMERO: Si hay video, agregar tarjeta de video
+    // 1. PRIMERO: Si hay pictograma, agregar tarjeta de pictograma
+    if (level.pictogramaUrl != null && level.pictogramaUrl!.isNotEmpty) {
+      contents.add(
+        ContentCardData(
+          type: ContentType.pictogram,
+          title: level.titulo,
+          description: 'Pictograma del nivel',
+          imagePath: level.pictogramaUrl!,
+        ),
+      );
+    }
+
+    // 2. SEGUNDO: Si hay video, agregar tarjeta de video
     if (level.videoUrl != null && level.videoUrl!.isNotEmpty) {
       contents.add(
         ContentCardData(
@@ -763,17 +777,6 @@ class _LevelTimelineScreenState extends State<LevelTimelineContent>
       );
     }
 
-    // 2. SEGUNDO: Si hay pictograma, agregar tarjeta de pictograma
-    if (level.pictogramaUrl != null && level.pictogramaUrl!.isNotEmpty) {
-      contents.add(
-        ContentCardData(
-          type: ContentType.pictogram,
-          title: level.titulo,
-          description: 'Pictograma del nivel',
-          imagePath: level.pictogramaUrl!,
-        ),
-      );
-    }
 
     // 3. TERCERO: Si hay audio, agregar tarjeta de audio
     if (level.audioUrl != null && level.audioUrl!.isNotEmpty) {

--- a/lib/features/learning_module/view/preview_cards.dart
+++ b/lib/features/learning_module/view/preview_cards.dart
@@ -403,50 +403,39 @@ class _VideoPreviewCardState extends State<VideoPreviewCard>
                                       crossAxisAlignment:
                                           CrossAxisAlignment.center,
                                       children: [
-                                        IconButton(
-                                          padding: EdgeInsets.zero,
-                                          constraints: const BoxConstraints(),
-                                          icon: SvgPicture.asset(
-                                            _viewModel
-                                                    .videoController
-                                                    .value
-                                                    .isPlaying
+                                        GestureDetector(
+                                          onTap: _viewModel.togglePlayPause,
+                                          child: SvgPicture.asset(
+                                            _viewModel.videoController.value.isPlaying
                                                 ? 'assets/icons/pausebutton.svg'
                                                 : 'assets/icons/playbuttoncontroller.svg',
-                                            width: 30,
-                                            height: 30,
-                                          ),
-                                          onPressed: _viewModel.togglePlayPause,
-                                        ),
-
-                                        Text(
-                                          '${_viewModel.formatDuration(_viewModel.videoController.value.position)} / ${_viewModel.formatDuration(_viewModel.videoController.value.duration)}',
-                                          style: const TextStyle(
-                                            color: Colors.white,
-                                            fontSize: 16,
+                                            width: 28,
+                                            height: 28,
                                           ),
                                         ),
 
-                                        IconButton(
-                                          padding: EdgeInsets.zero,
-                                          constraints: const BoxConstraints(),
-                                          icon: SvgPicture.asset(
+                                        Flexible(
+                                          child: Text(
+                                            '${_viewModel.formatDuration(_viewModel.videoController.value.position)} / ${_viewModel.formatDuration(_viewModel.videoController.value.duration)}',
+                                            style: const TextStyle(
+                                              color: Colors.white,
+                                              fontSize: 13,
+                                            ),
+                                            overflow: TextOverflow.ellipsis,
+                                          ),
+                                        ),
+
+                                        GestureDetector(
+                                          onTap: _viewModel.replay,
+                                          child: SvgPicture.asset(
                                             'assets/icons/replay.svg',
-                                            width: 30,
-                                            height: 30,
+                                            width: 28,
+                                            height: 28,
                                           ),
-                                          onPressed: _viewModel.replay,
                                         ),
 
-                                        IconButton(
-                                          padding: EdgeInsets.zero,
-                                          constraints: const BoxConstraints(),
-                                          icon: SvgPicture.asset(
-                                            'assets/icons/fullscreen.svg',
-                                            width: 30,
-                                            height: 30,
-                                          ),
-                                          onPressed: () {
+                                        GestureDetector(
+                                          onTap: () {
                                             Navigator.of(context).push(
                                               MaterialPageRoute(
                                                 builder: (context) =>
@@ -460,6 +449,11 @@ class _VideoPreviewCardState extends State<VideoPreviewCard>
                                               ),
                                             );
                                           },
+                                          child: SvgPicture.asset(
+                                            'assets/icons/fullscreen.svg',
+                                            width: 28,
+                                            height: 28,
+                                          ),
                                         ),
                                       ],
                                     ),
@@ -512,6 +506,17 @@ class _VideoPreviewCardState extends State<VideoPreviewCard>
         }
       },
     );
+  }
+
+  @override
+  void deactivate() {
+    // Pausar cada vez que se sale de la pantalla (incluso temporalmente) para evitar que el video siga sonando en segundo plano
+    try {
+      if (_viewModel.videoController.value.isPlaying) {
+        _viewModel.videoController.pause();
+      }
+    } catch (_) {}
+    super.deactivate();
   }
 
   @override

--- a/lib/features/learning_module/view/preview_cards.dart
+++ b/lib/features/learning_module/view/preview_cards.dart
@@ -510,7 +510,7 @@ class _VideoPreviewCardState extends State<VideoPreviewCard>
 
   @override
   void deactivate() {
-    // Pause whenever this card leaves the viewport (page swipe in carousel)
+    // Pausar cada que la tarjeta se desactiva del viewport (deslizar en el carrusel) para evitar que el video siga sonando en segundo plano
     try {
       if (_viewModel.videoController.value.isPlaying) {
         _viewModel.videoController.pause();

--- a/lib/features/learning_module/view/preview_cards.dart
+++ b/lib/features/learning_module/view/preview_cards.dart
@@ -248,7 +248,7 @@ class _VideoPreviewCardState extends State<VideoPreviewCard>
     _viewModel.addListener(() {
       if (mounted) setState(() {});
     });
-    
+
     // Verificar periódicamente si el video se completó
     _completionCheckTimer = Timer.periodic(const Duration(milliseconds: 500), (timer) {
       if (!mounted || _hasNotifiedCompletion) return;
@@ -510,7 +510,7 @@ class _VideoPreviewCardState extends State<VideoPreviewCard>
 
   @override
   void deactivate() {
-    // Pausar cada vez que se sale de la pantalla (incluso temporalmente) para evitar que el video siga sonando en segundo plano
+    // Pause whenever this card leaves the viewport (page swipe in carousel)
     try {
       if (_viewModel.videoController.value.isPlaying) {
         _viewModel.videoController.pause();

--- a/lib/features/learning_module/viewmodel/learning_viewmodel.dart
+++ b/lib/features/learning_module/viewmodel/learning_viewmodel.dart
@@ -203,7 +203,7 @@ class LearningViewModel extends ChangeNotifier {
       final nivelesTemporales = levelsData.map((data) {
         final levelId = data['id']?.toString() ?? '';
         final levelProgress = userProgress[levelId];
-        
+
         return _createModuleLevelInfoWithProgress(
           data,
           levelProgress,
@@ -331,7 +331,7 @@ class LearningViewModel extends ChangeNotifier {
 
       // Si hay progreso, verificar estado
       if (progress != null) {
-        final status = progress['status']?.toString()?.toLowerCase();
+        final status = progress['status']?.toString().toLowerCase();
         final estrellas = progress['estrellas'] as int? ?? 0;
         
         if (status == 'completed' || estrellas > 0) {

--- a/lib/features/learning_module/viewmodel/learning_viewmodel.dart
+++ b/lib/features/learning_module/viewmodel/learning_viewmodel.dart
@@ -204,6 +204,7 @@ class LearningViewModel extends ChangeNotifier {
         final levelId = data['id']?.toString() ?? '';
         final levelProgress = userProgress[levelId];
 
+
         return _createModuleLevelInfoWithProgress(
           data,
           levelProgress,

--- a/lib/features/learning_module/viewmodel/level_timeline_viewmodel.dart
+++ b/lib/features/learning_module/viewmodel/level_timeline_viewmodel.dart
@@ -68,7 +68,9 @@ class LevelTimelineViewModel extends ChangeNotifier {
             previewTitle: titleWithPrefix,
             whatState: level.estado,
             stars: level.estrellas,
-            posibleImagePreview: level.pictogramaUrl,
+            posibleImagePreview: (level.actividadData?['pictogramaUrl'] as String?)?.isNotEmpty == true
+                ? level.actividadData!['pictogramaUrl'] as String
+                : level.pictogramaUrl,
             minigameData: level.actividadData,
             actividadType: level.actividadType,
             levelId: level.id,

--- a/lib/features/learning_module/viewmodel/video_viewmodel.dart
+++ b/lib/features/learning_module/viewmodel/video_viewmodel.dart
@@ -27,7 +27,7 @@ class VideoViewModel extends ChangeNotifier {
       _isExternalController = true;
       if (_videoController.value.isInitialized) {
         _initializeVideoFuture = Future.value();
-        // Defer setLooping to avoid triggering notifyListeners during build
+        // setLooping a false para evitar el trigger a notifyListeners() durante la construcción del widget
         Future.microtask(() {
           _videoController.setLooping(false);
         });
@@ -39,7 +39,7 @@ class VideoViewModel extends ChangeNotifier {
       }
     }
 
-    // Defer listener attachment to avoid setState() during build
+    // Referir el listener para evitar setState() durante la construcción del widget
     Future.microtask(() {
       _videoController.addListener(() {
         notifyListeners();

--- a/lib/features/learning_module/viewmodel/video_viewmodel.dart
+++ b/lib/features/learning_module/viewmodel/video_viewmodel.dart
@@ -27,8 +27,10 @@ class VideoViewModel extends ChangeNotifier {
       _isExternalController = true;
       if (_videoController.value.isInitialized) {
         _initializeVideoFuture = Future.value();
-        // Asegurarse de que el loop esté desactivado (no reproducir automáticamente)
-        _videoController.setLooping(false);
+        // Defer setLooping to avoid triggering notifyListeners during build
+        Future.microtask(() {
+          _videoController.setLooping(false);
+        });
       } else {
         _initializeVideoFuture = _videoController.initialize().then((_) {
           // Desactivar loop por defecto - el video solo se reproduce cuando el usuario lo inicia
@@ -37,8 +39,11 @@ class VideoViewModel extends ChangeNotifier {
       }
     }
 
-    _videoController.addListener(() {
-      notifyListeners();
+    // Defer listener attachment to avoid setState() during build
+    Future.microtask(() {
+      _videoController.addListener(() {
+        notifyListeners();
+      });
     });
   }
 


### PR DESCRIPTION
* Widget del reproductor de video añadido de vuelta al carrusel, para los niveles que tengan video en el bucket de Firestore se podrán visualizar en el preview del nivel.
* Bugfixes menor para la integración del widget de video con la carga desde Firestore (campo ```videoUrl```).
* Añadido caching al recurso del video y buffering en el background.